### PR TITLE
Support of different storage engines for MySQL

### DIFF
--- a/lib/sqlstore/mapping.js
+++ b/lib/sqlstore/mapping.js
@@ -78,6 +78,15 @@ var Mapping = function(store, type, definition) {
         "value": definition.schema,
         "enumerable": true
     });
+    
+    /**
+     * The schema name
+     * @type String
+     */
+    Object.defineProperty(this, "engine", {
+        "value": definition.engine,
+        "enumerable": true
+    });
 
     // convert all defined properties into their appropriate property mapping instances
     for (var propName in definition.properties) {

--- a/lib/sqlstore/store.js
+++ b/lib/sqlstore/store.js
@@ -336,7 +336,7 @@ Store.prototype.createTable = function(conn, dialect, mapping) {
         }
     }
     return sqlUtils.createTable(conn, dialect, mapping.schemaName, mapping.tableName,
-             columns, primaryKeys);
+             columns, primaryKeys, mapping.engine);
 };
 
 /**

--- a/lib/sqlstore/util.js
+++ b/lib/sqlstore/util.js
@@ -20,7 +20,7 @@ function close(obj) {
  * @param {Array} primaryKey An array containing the primary key columns
  * @param {String} engineType Optional engine type, solely for mysql databases
  */
-function createTable(conn, dialect, schemaName, tableName, columns, primaryKey) {
+function createTable(conn, dialect, schemaName, tableName, columns, primaryKey, engineType) {
     var sqlBuf = new java.lang.StringBuffer();
     sqlBuf.append("CREATE TABLE ");
     // FIXME: there's mapping.getQualifiedTableName() ...
@@ -57,9 +57,9 @@ function createTable(conn, dialect, schemaName, tableName, columns, primaryKey) 
         }).join(", ")).append(")");
     }
     sqlBuf.append(")");
-    var engineType = dialect.getEngineType();
-    if (engineType != null) {
-        sqlBuf.append(" ENGINE=").append(engineType);
+    var engineTypeName = engineType || dialect.getEngineType();
+    if (engineTypeName != null) {
+        sqlBuf.append(" ENGINE=").append(engineTypeName);
     }
     log.debug("Creating table: " + sqlBuf.toString());
 


### PR DESCRIPTION
This is useful for fulltext search support. This will be available for InnoDB with the next stable release 5.6, but for all previous versions it's only available for MyISAM.
