### PR TITLE
output PEG.SyntaxError

### DIFF
--- a/lib/sqlstore/query/query.js
+++ b/lib/sqlstore/query/query.js
@@ -15,7 +15,18 @@ var Query = exports.Query = function(store, queryStr) {
                     if (store.queryCache.containsKey(queryStr)) {
                         ast = store.queryCache.get(queryStr);
                     } else {
-                        ast = Parser.parse(queryStr);
+                        try {
+                            ast = Parser.parse(queryStr);
+                        } catch (e) {
+                            // assuming this is a PEG.SyntaxError
+                            var strings = require('ringo/utils/strings');
+                            throw new Error([
+                                'Could not parse query.',
+                                '"' + queryStr + '"',
+                                strings.repeat(' ', parseInt(e.column, 10)) + '^',
+                                e.message + ' At column: ' + e.column
+                            ].join('\n'));
+                        }
                         store.queryCache.put(queryStr, ast);
                     }
                 }


### PR DESCRIPTION
my attempt at fixing #13

this will output:

```
Error: Could not parse query.
"slect foo fram bar"
      ^
Expected "." or [A-Za-z0-9_\-] but " " found. At column: 6
    at ringo-sqlstore/lib/sqlstore/query/query.js:23 (anonymous)
    at ringo-sqlstore/lib/sqlstore/query/query.js:72 (anonymous)
    at ringo-sqlstore/lib/sqlstore/store.js:679 (anonymous)
    at /home/simon/ositestats/query stuff:50
```
