### PR TITLE
make ConnectionPool more easily accessible

### DIFF
--- a/lib/sqlstore/main.js
+++ b/lib/sqlstore/main.js
@@ -2,4 +2,5 @@
  * Main module
  */
 exports.Store = require("./store").Store;
-exports.Query = require("./query").Query;
+exports.Query = require("./query/query").Query;
+exports.ConnectionPool = require('./connectionpool').ConnectionPool;

--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
     "engines": {
         "ringojs": ">= 0.8"
     },
-    "main": "./lib/sqlstore/store.js"
+    "main": "./lib/sqlstore/main.js"
 }


### PR DESCRIPTION
`ConnectionPool` was only accessible through:

```
 require('ringo-sqlstore/sqlstore/connectionpool')
```

And "main.js" was unused while I expected it to be the main module
of the package. I'm not sure `Query` needs to be exported? But I
left it there for now.
