### PR TITLE
join multiple JOINs with space not comma

### DIFF
--- a/lib/query/sqlgenerator.js
+++ b/lib/query/sqlgenerator.js
@@ -459,7 +459,7 @@ SqlGenerator.prototype.visitFromClause = function(node) {
 SqlGenerator.prototype.visitJoinClause = function(node) {
     return node.list.map(function(join) {
         return join.accept(this);
-    }, this).join(", ");
+    }, this).join(" ");
 };
 
 /**


### PR DESCRIPTION
trivial fix i hope. 

ran into this when doing multiple joins in one query:

```
Wrapped org.h2.jdbc.JdbcSQLException: Syntax error in SQL statement "SELECT ""Adresse"".""rw"", ""Adresse"".""hw"", ""Ortschaft"".""ortsname"", ""Gemeinde"".""gemeindename"", ""Strasse"".""strassenname"", ""Adresse"".""hausnrzahl1"" FROM ""Adresse"" INNER JOIN ""Strasse"" ON ""Adresse"".""skz"" = ""Strasse"".""skz"", INNER[*] JOIN ""Ortschaft"" ON (""Adresse"".""okz"" = ""Ortschaft"".""okz"" AND ""Adresse"".""gkz"" = ""Ortschaft"".""gkz""), INNER JOIN ""Gemeinde"" ON ""Adresse"".""gkz"" = ""Gemeinde"".""gkz"" LIMIT 100"; expected "identifier"; SQL statement:
SELECT "Adresse"."rw", "Adresse"."hw", "Ortschaft"."ortsname", "Gemeinde"."gemeindename", "Strasse"."strassenname", "Adresse"."hausnrzahl1" FROM "Adresse" INNER JOIN "Strasse" ON "Adresse"."skz" = "Strasse"."skz", INNER JOIN "Ortschaft" ON ("Adresse"."okz" = "Ortschaft"."okz" AND "Adresse"."gkz" = "Ortschaft"."gkz"), INNER JOIN "Gemeinde" ON "Adresse"."gkz" = "Gemeinde"."gkz" LIMIT 100 [42001-191]
	at ringo-sqlstore/lib/database/statements.js:214 (anonymous)
	at ringo-sqlstore/lib/query/query.js:28 (anonymous)
	at ringo-sqlstore/lib/store.js:499 (anonymous)
```